### PR TITLE
Feature/fix csml

### DIFF
--- a/lib/integrations/bot_processor_service.rb
+++ b/lib/integrations/bot_processor_service.rb
@@ -38,7 +38,19 @@ class Integrations::BotProcessorService
 
     return message.content_attributes['submitted_values']&.first&.dig('value') if event_name == 'message.updated'
 
-    message.content
+    return message.content if message.content?
+
+    message_attachments(message)
+  end
+
+  def message_attachments(message)
+    return unless message.attachments.present?
+
+    # gps
+    return message.attachments.map { |attachment| "#{attachment[:coordinates_lat]}, #{attachment[:coordinates_long]}" }.join('\n') if message.attachments.first[:file_type].to_sym == :location
+
+    # file
+    return message.attachments.map(&:file_url).join('\n')
   end
 
   def processable_message?(message)

--- a/lib/integrations/csml/processor_service.rb
+++ b/lib/integrations/csml/processor_service.rb
@@ -67,6 +67,7 @@ class Integrations::Csml::ProcessorService < Integrations::BotProcessorService
     # We do not support wait, typing now.
     csml_messages.each do |csml_message|
       create_messages(csml_message, conversation)
+      sleep 1
     end
   end
 


### PR DESCRIPTION
# Pull Request Template

## Description

To fix CSML related issues:
1. Outgoing message to Whatsapp via meta / twilio is not in correct sequence.
2. Uploading a file / sending GPS location don't trigger CSML call because content is NULL

## Type of change

1. Added 1 second delay sleep 1 in incoming csml message creation loop
2. If message content is null, use attachments. Added GPS latlng string and file_url according to attachment file_type

## How Has This Been Tested?

Testing using local server calling to CSML proxy.

1. Messages are successfully created in 1 second interval.
2. Successfully trigger CSML call by uploading an image. Didn't test by sending GPS location.


## Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
